### PR TITLE
fix(option): allow options to work

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@
 const got = require('got');
 
 const awaitUrl = (url, option) => {
-    const config = Object.assign({}, option, {
+    const config = Object.assign({
         interval : 1000,
         tries    : 60
-    });
+    }, option);
 
     return new Promise((resolve, reject) => {
         const attempt = async (tries) => {


### PR DESCRIPTION
Because `Object.assign` will make the last argument win in the event of a conflict. So by putting `option` last, then the user can override the defaults.